### PR TITLE
Add new argument expected by action_view 3.2.22.2

### DIFF
--- a/lib/sack/template_resolver.rb
+++ b/lib/sack/template_resolver.rb
@@ -1,5 +1,5 @@
 class Sack::TemplateResolver < ::ActionView::FileSystemResolver
-  def find_templates(name, prefix, partial, details)
+  def find_templates(name, prefix, partial, details, outside_app_allowed = false)
     if prefix.include?('/')
       parts  = prefix.split '/'
 


### PR DESCRIPTION
The signature for the method `find_templates` changed between Rails 3.2.22.1 and Rails 3.2.22.2. This updates the signature we're using.